### PR TITLE
Remove Dark Sky integration (deprecated); fix MD formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Illuminance Sensor
+
 Estimates outdoor illuminance based on current weather conditions and time of day. At night the value is 10. From a little before sunrise to a little after the value is ramped up to whatever the current conditions indicate. The same happens around sunset, except the value is ramped down. Below is an example of what that might look like over a three day period.
 
-<p align="center">
-  <img src=images/illuminance_history.png>
-</p>
+![Image of sensor history](images/illuminance_history.png)
 
 The following sources of weather data are supported:
 
-* [Dark Sky Sensor (icon)](https://www.home-assistant.io/components/sensor.darksky/)
-* [Dark Sky Weather](https://www.home-assistant.io/components/weather.darksky/)
 * Weather Underground
 * [YR (symbol)](https://www.home-assistant.io/components/sensor.yr/)
 
 Follow the installation instructions below.
 Then add the desired configuration. Here is an example of a typical configuration:
+
 ```yaml
 sensor:
   - platform: illuminance
     entity_id: sensor.yr_symbol
 ```
+
 ## Installation
+
 Place a copy of:
 
 [`__init__.py`](custom_components/illuminance/__init__.py) at `<config>/custom_components/illuminance/__init__.py`  
@@ -31,35 +31,18 @@ where `<config>` is your Home Assistant configuration directory.
 >__NOTE__: Do not download the file by using the link above directly. Rather, click on it, then on the page that comes up use the `Raw` button.
 
 ## Configuration variables
-- **api_key**: Weather Underground API key. Required when using WU.
-- **entity_id**: Entity ID of Dark Sky or YR entity. See examples below. Required when using Dark Sky or YR.
-- **name** (*Optional*): Name of the sensor. Default is `Illuminance`.
-- **scan_interval** (*Optional*): Polling interval.  For non-WU configs only applies during ramp up period around sunrise and ramp down period around sunset. Minimum is 5 minutes. Default is 5 minutes.
-- **query**: Weather Underground query. See https://www.wunderground.com/weather/api/d/docs?d=data/index. Required when using WU.
+
+* **api_key**: Weather Underground API key. Required when using WU.
+* **entity_id**: Entity ID of YR entity. See examples below. Required when using YR.
+* **name** (*Optional*): Name of the sensor. Default is `Illuminance`.
+* **scan_interval** (*Optional*): Polling interval.  For non-WU configs only applies during ramp up period around sunrise and ramp down period around sunset. Minimum is 5 minutes. Default is 5 minutes.
+* **query**: Weather Underground query. See [here](https://www.wunderground.com/weather/api/d/docs?d=data/index). Required when using WU.
+
 ## Examples
-### Dark Sky Sensor
-```
-sensor:
-  - platform: darksky
-    api_key: !secret ds_api_key
-    monitored_conditions:
-      - icon
-  - platform: illuminance
-    name: DSS Illuminance
-    entity_id: sensor.dark_sky_icon
-```
-### Dark Sky Weather
-```
-weather:
-  - platform: darksky
-    api_key: !secret ds_api_key
-sensor:
-  - platform: illuminance
-    name: DSW Illuminance
-    entity_id: weather.dark_sky
-```
+
 ### YR Sensor
-```
+
+```yaml
 sensor:
   - platform: yr
     monitored_conditions:
@@ -68,8 +51,10 @@ sensor:
     name: YRS Illuminance
     entity_id: sensor.yr_symbol
 ```
+
 ### Weather Underground
-```
+
+```yaml
 sensor:
   - platform: illuminance
     name: WU Illuminance
@@ -78,7 +63,11 @@ sensor:
     scan_interval:
       minutes: 30
 ```
+
 ## Caveats
+
 Weather Underground no long provides free API keys. In fact, as of this writing they have notified that the REST API will be discontinued.
+
 ## Releases Before 2.1.0
-See https://github.com/pnbruckner/homeassistant-config/blob/master/docs/illuminance.md.
+
+See [here](https://github.com/pnbruckner/homeassistant-config/blob/master/docs/illuminance.md)

--- a/custom_components/illuminance/__init__.py
+++ b/custom_components/illuminance/__init__.py
@@ -1,3 +1,3 @@
 """Illuminance Sensor."""
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/custom_components/illuminance/sensor.py
+++ b/custom_components/illuminance/sensor.py
@@ -1,8 +1,7 @@
 """
 Illuminance Sensor.
 
-A Sensor platform that estimates outdoor illuminance from Weather Underground,
-YR or Dark Sky current conditions.
+A Sensor platform that estimates outdoor illuminance from Weather Underground or YR current conditions.
 """
 import asyncio
 import datetime as dt
@@ -14,11 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN, PLATFORM_SCHEMA)
-from homeassistant.components.darksky.sensor import (
-    ATTRIBUTION as DSS_ATTRIBUTION)
 from homeassistant.components.yr.sensor import ATTRIBUTION as YRS_ATTRIBUTION
-from homeassistant.components.darksky.weather import (
-    ATTRIBUTION as DSW_ATTRIBUTION, MAP_CONDITION as DSW_MAP_CONDITION)
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_ENTITY_ID, CONF_API_KEY, CONF_NAME,
     CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START)
@@ -50,12 +45,6 @@ YR_MAPPING = (
     (2500, (4, )),
     (7500, (2, 3)),
     (10000, (1, )))
-DARKSKY_MAPPING = (
-    (200, ('hail', 'lightning')),
-    (1000, ('fog', 'rainy', 'snowy', 'snowy-rainy')),
-    (2500, ('cloudy', )),
-    (7500, ('partlycloudy', )),
-    (10000, ('clear-night', 'sunny', 'windy')))
 
 CONF_QUERY = 'query'
 
@@ -167,7 +156,7 @@ class IlluminanceSensor(Entity):
         """Return if should poll for status."""
         # For the system (i.e., EntityPlatform) to configure itself to
         # periodically call our async_update method any call to this method
-        # during initializaton must return True. After that, for WU we'll
+        # during initialization must return True. After that, for WU we'll
         # always poll, and for others we'll only need to poll during the ramp
         # up and down periods around sunrise and sunset, and then once more
         # when period is done to make sure ramping is completed.
@@ -247,13 +236,7 @@ class IlluminanceSensor(Entity):
                                   ATTR_ATTRIBUTION, self._entity_id)
                 return
             raw_conditions = state.state
-            if attribution in (DSS_ATTRIBUTION, DSW_ATTRIBUTION):
-                if state.domain == SENSOR_DOMAIN:
-                    conditions = DSW_MAP_CONDITION.get(raw_conditions)
-                else:
-                    conditions = raw_conditions
-                mapping = DARKSKY_MAPPING
-            elif attribution == YRS_ATTRIBUTION:
+            if attribution == YRS_ATTRIBUTION:
                 try:
                     conditions = int(raw_conditions)
                 except (TypeError, ValueError):


### PR DESCRIPTION
The config-checker add-on said that my current configuration was incompatible with upgrading to HA-core v0.113.2. The error message indicated something related to 'forecastio', which is a python module used by the Dark Sky integration. I don't use Dark Sky and it is going to be EOL this year, so feel free to merge this PR whenever you feel it is appropriate.