### PR TITLE
Support Buienradar weather sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following sources of weather data are supported:
 * [AccuWeather](https://www.home-assistant.io/integrations/accuweather/)
 * [ecobee](https://www.home-assistant.io/integrations/ecobee/)
 * [OpenWeatherMap](https://www.home-assistant.io/integrations/openweathermap/)
+* [Buienradar](https://www.home-assistant.io/integrations/buienradar/)
 
 ## Setup
 Follow the installation instructions below.
@@ -94,6 +95,13 @@ sensor:
   - platform: illuminance
     name: Estimated Illuminance
     entity_id: weather.openweathermap
+```
+### Buienradar
+```
+sensor:
+  - platform: illuminance
+    name: Estimated Illuminance
+    entity_id: weather.buienradar
 ```
 ## Releases Before 2.1.0
 See https://github.com/pnbruckner/homeassistant-config/blob/master/docs/illuminance.md.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can use [HACS](https://hacs.xyz/) to manage installation and updates by addi
 - **scan_interval** (*Optional*): Update interval. Minimum is 5 minutes. Default is 5 minutes.
 ## Examples
 ### Dark Sky Sensor
-```
+```yaml
 sensor:
   - platform: darksky
     api_key: !secret ds_api_key
@@ -73,7 +73,7 @@ sensor:
     entity_id: sensor.dark_sky_icon
 ```
 ### Dark Sky Weather
-```
+```yaml
 weather:
   - platform: darksky
     api_key: !secret ds_api_key
@@ -83,21 +83,21 @@ sensor:
     entity_id: weather.dark_sky
 ```
 ### Met.no, AccuWeather or ecobee
-```
+```yaml
 sensor:
   - platform: illuminance
     name: Estimated Illuminance
     entity_id: weather.home
 ```
 ### OpenWeatherMap
-```
+```yaml
 sensor:
   - platform: illuminance
     name: Estimated Illuminance
     entity_id: weather.openweathermap
 ```
 ### Buienradar
-```
+```yaml
 sensor:
   - platform: illuminance
     name: Estimated Illuminance

--- a/custom_components/illuminance/sensor.py
+++ b/custom_components/illuminance/sensor.py
@@ -116,6 +116,21 @@ OWM_MAPPING = (
     (2, ("partlycloudy",)),
     (1, ("sunny", "clear-night")),
 )
+BR_MAPPING = (
+    (10, ("lightning", "lightning-rainy", "pouring")),
+    (
+        5,
+        (
+            "cloudy",
+            "fog",
+            "rainy",
+            "snowy",
+            "snowy-rainy",
+        ),
+    ),
+    (2, ("partlycloudy",)),
+    (1, ("sunny",)),
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -215,6 +230,8 @@ class IlluminanceSensor(Entity):
                 self._sk_mapping = ECOBEE_MAPPING
             elif attribution == OWM_ATTRIBUTION:
                 self._sk_mapping = OWM_MAPPING
+            elif "buienradar" in attribution.lower():
+                self._sk_mapping = BR_MAPPING
             else:
                 _LOGGER.error(
                     "%s: Unsupported sensor: %s, attribution: %s",

--- a/custom_components/illuminance/sensor.py
+++ b/custom_components/illuminance/sensor.py
@@ -208,6 +208,11 @@ class IlluminanceSensor(Entity):
                 if self.hass.is_running:
                     _LOGGER.error("%s: State not found: %s", self.name, self._entity_id)
                 return False
+
+            if "buienradar" in self._entity_id:
+                self._sk_mapping = BR_MAPPING
+                return True
+
             attribution = state.attributes.get(ATTR_ATTRIBUTION)
             if not attribution:
                 _LOGGER.error(


### PR DESCRIPTION
Stumbled upon this today, as I needed a reliable non-hardware source of lux for [Clight](https://github.com/FedeDP/Clight).

Adresses #21.

Buienradar initializes the attribution lazily based on a network request, thus it's not available during the `async_added_to_hass` lifecycle hook.