### PR TITLE
Fix dependency setup error

### DIFF
--- a/custom_components/illuminance/manifest.json
+++ b/custom_components/illuminance/manifest.json
@@ -5,7 +5,8 @@
   "documentation": "https://github.com/pnbruckner/ha-illuminance/blob/master/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-illuminance/issues",
   "requirements": [],
-  "dependencies": ["darksky"],
+  "dependencies": [],
+  "after_dependencies": ["darksky"],
   "iot_class": "calculated",
   "codeowners": ["@pnbruckner"]
 }


### PR DESCRIPTION
Put darksky in after_dependencies instead of dependencies.

Fixes #33.