### PR TITLE
Make docs clearer that this integration creates a new sensor entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Illuminance Sensor
-Estimates outdoor illuminance based on either sun elevation or time of day. In either case, the value is adjusted based on current weather conditions.
+Creates a `sensor` entity that estimates outdoor illuminance based on either sun elevation or time of day.
+In either case, the value is adjusted based on current weather conditions obtained from another, existing entity.
+
 
 ## Modes of operation
 Two modes are available: normal & simple. The desired mode is selected via the [configuration](#configuration-variables).
@@ -40,6 +42,9 @@ Then add the desired configuration. Here is an example of a typical configuratio
 ```yaml
 sensor:
   - platform: illuminance
+    # Name of new sensor entity
+    name: Home Outdoor Illuminance
+    # Existing entity that provides current weather conditions
     entity_id: weather.home
 ```
 
@@ -73,7 +78,7 @@ where `<config>` is your Home Assistant configuration directory.
 This custom integration supports HomeAssistant versions 2021.12 or newer, using Python 3.9 or newer.
 
 ## Configuration variables
-- **entity_id**: Entity ID of entity that indicates current weather conditions.
+- **entity_id**: Entity ID of another entity that indicates current weather conditions.
 - **mode** (*Optional*): Mode of operation. Choices are `normal` (default) which uses sun elevation, and `simple` which uses time of day.
 - **name** (*Optional*): Name of the sensor. Default is `Illuminance`.
 - **scan_interval** (*Optional*): Update interval. Minimum is 5 minutes. Default is 5 minutes.

--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
 # Illuminance Sensor
 
-Estimates outdoor illuminance based on either sun elevation or time of day.
-In either case, the value is adjusted based on current weather conditions.
+Creates a `sensor` entity that estimates outdoor illuminance based on either sun elevation or time of day.
+In either case, the value is adjusted based on current weather conditions obtained from another, existing entity.
 The weather data can be from any entity whose state is either a
 [weather condition](https://www.home-assistant.io/integrations/weather/#condition-mapping)
 or a cloud coverage percentage.


### PR DESCRIPTION
It can be confusing for some users, especially those that don't normally do configuration via YAML, that this integration creates a new `sensor` entity, and only _uses_ another entity (specified by the `entity_id` configuration option) as an input of current weather conditions. Hopefully these changes make it clearer.

Resolves #37 