### PR TITLE
Avoid reloading config when not in correct state

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
     name: With hassfest
     steps:
     - name: 📥 Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🏃 Hassfest validation
       uses: "home-assistant/actions/hassfest@master"

--- a/custom_components/illuminance/__init__.py
+++ b/custom_components/illuminance/__init__.py
@@ -99,6 +99,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config entry update."""
+    if not entry.state.recoverable:
+        return
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/illuminance/config_flow.py
+++ b/custom_components/illuminance/config_flow.py
@@ -132,12 +132,9 @@ class IlluminanceConfigFlow(ConfigFlow, IlluminanceFlow, domain=DOMAIN):
             cast(timedelta, data[CONF_SCAN_INTERVAL]).total_seconds() / 60
         )
         if existing_entry := await self.async_set_unique_id(data.pop(CONF_UNIQUE_ID)):
-            if not self.hass.config_entries.async_update_entry(
+            self.hass.config_entries.async_update_entry(
                 existing_entry, title=title, options=data
-            ):
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(existing_entry.entry_id)
-                )
+            )
             return self.async_abort(reason="already_configured")
 
         return self.async_create_entry(title=title, data={}, options=data)

--- a/custom_components/illuminance/sensor.py
+++ b/custom_components/illuminance/sensor.py
@@ -153,7 +153,7 @@ Num = Union[float, int]
 
 
 @dataclass
-class IlluminanceSensorEntityDescription(SensorEntityDescription):
+class IlluminanceSensorEntityDescription(SensorEntityDescription):  # type: ignore[misc]
     """Illuminance sensor entity description."""
 
     weather_entity: str | None = None


### PR DESCRIPTION
First noticed in 2024.3.0b1, either something unexpected changed, or timing has changed, because a reload that worked ok before is now running while the config entry is still being set up. This change prevents reloads from being started when the config is not in the correct state.

Fixes #61 